### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: CI
 
 on: [push]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/stories-with-team/stories-with-team/security/code-scanning/1](https://github.com/stories-with-team/stories-with-team/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/test.yml`. Since the workflow only checks out code, sets up Node, caches dependencies, and runs tests, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`, which allows the workflow to read repository contents but not modify them. The `permissions` block should be added at the root level of the workflow file (above `jobs:`) to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
